### PR TITLE
Update Index crawler attribute to Optional

### DIFF
--- a/Monocle/Index/Type.dhall
+++ b/Monocle/Index/Type.dhall
@@ -1,5 +1,5 @@
     ../Tenant/Type.dhall
 //\\  { users : Optional (List Text)
       , task_crawlers : Optional (List ../TaskCrawler/Type.dhall)
-      , crawler : ../Crawler/Type.dhall
+      , crawler : Optional ../Crawler/Type.dhall
       }

--- a/Monocle/Index/default.dhall
+++ b/Monocle/Index/default.dhall
@@ -1,4 +1,5 @@
     ../Tenant/default.dhall
 //  { users = None (List Text)
     , task_crawlers = None (List ../TaskCrawler/Type.dhall)
+    , crawler = None ../Crawler/Type.dhall
     }

--- a/example/demo-node.dhall
+++ b/example/demo-node.dhall
@@ -70,7 +70,7 @@ let --| The ansible index configuration
 
       in  Monocle.Index::{
           , index = "ansible"
-          , crawler = Monocle.Crawler::{
+          , crawler = Some Monocle.Crawler::{
             , loop_delay = 300
             , github_orgs = Some
                 (   Prelude.List.map
@@ -99,7 +99,7 @@ let --| Create a github crawler configuration for monocle
       \(name : Text) ->
         Monocle.Index::{
         , index = name
-        , crawler = Monocle.Crawler::{
+        , crawler = Some Monocle.Crawler::{
           , loop_delay = 300
           , github_orgs = Some [ mkSimpleGHOrg (None Text) name ]
           }


### PR DESCRIPTION
This change enables using both new Tenant and old Index in the same
configuration.