### PR TITLE
Make gerrit insecure toggle optional

### DIFF
--- a/Monocle/Provider/Gerrit/Type.dhall
+++ b/Monocle/Provider/Gerrit/Type.dhall
@@ -1,7 +1,7 @@
 { gerrit_url : Text
 , gerrit_login : Optional Text
 , gerrit_password : Optional Text
-, gerrit_url_insecure : Bool
+, gerrit_url_insecure : Optional Bool
 , gerrit_prefix : Optional Text
 , gerrit_repositories : Optional (List Text)
 }

--- a/Monocle/Provider/Gerrit/default.dhall
+++ b/Monocle/Provider/Gerrit/default.dhall
@@ -1,4 +1,4 @@
-{ gerrit_url_insecure = False
+{ gerrit_url_insecure = None Bool
 , gerrit_login = None Text
 , gerrit_password = None Text
 , gerrit_prefix = None Text


### PR DESCRIPTION
This change makes it easier to decode a yaml file.