### PR TITLE
Change token type to Optional and fix gitlab provider

### DIFF
--- a/Monocle/Provider/Bugzilla/Type.dhall
+++ b/Monocle/Provider/Bugzilla/Type.dhall
@@ -1,4 +1,4 @@
 { bugzilla_url : Text
-, bugzilla_token : Text
+, bugzilla_token : Optional Text
 , bugzilla_products : Optional (List Text)
 }

--- a/Monocle/Provider/Bugzilla/default.dhall
+++ b/Monocle/Provider/Bugzilla/default.dhall
@@ -1,1 +1,1 @@
-{ bugzilla_products = None (List Text) }
+{ bugzilla_token = None Text, bugzilla_products = None (List Text) }

--- a/Monocle/Provider/Github/Type.dhall
+++ b/Monocle/Provider/Github/Type.dhall
@@ -1,5 +1,5 @@
 { github_url : Optional Text
-, github_token : Text
+, github_token : Optional Text
 , github_organization : Text
 , github_repositories : Optional (List Text)
 }

--- a/Monocle/Provider/Github/default.dhall
+++ b/Monocle/Provider/Github/default.dhall
@@ -1,1 +1,4 @@
-{ github_url = None Text, github_repositories = None (List Text) }
+{ github_url = None Text
+, github_repositories = None (List Text)
+, github_token = None Text
+}

--- a/Monocle/Provider/Gitlab/Type.dhall
+++ b/Monocle/Provider/Gitlab/Type.dhall
@@ -1,5 +1,5 @@
 { gitlab_url : Optional Text
-, gitlab_token : Text
+, gitlab_token : Optional Text
+, gitlab_organization : Text
 , gitlab_repositories : Optional (List Text)
-, gitlab_organizations : Optional (List Text)
 }

--- a/Monocle/Provider/Gitlab/default.dhall
+++ b/Monocle/Provider/Gitlab/default.dhall
@@ -1,3 +1,4 @@
-{ gitlab_repositories = None (List Text)
-, gitlab_organizations = None (List Text)
+{ gitlab_url = None Text
+, gitlab_token = None Text
+, gitlab_repositories = None (List Text)
 }

--- a/Monocle/Workspace/Type.dhall
+++ b/Monocle/Workspace/Type.dhall
@@ -1,5 +1,5 @@
 { name : Text
-, crawlers_api_key : Text
+, crawlers_api_key : Optional Text
 , crawlers : List ../Crawler/Type.dhall
 , projects : Optional (List ../Project/Type.dhall)
 , idents : Optional (List ../Ident/Type.dhall)

--- a/example/config.dhall
+++ b/example/config.dhall
@@ -4,7 +4,6 @@ in  Monocle.Config::{
     , workspaces =
       [ Monocle.Workspace::{
         , name = "demo-index"
-        , crawlers_api_key = "super-secret"
         , crawlers =
           [ Monocle.Crawler::{
             , name = "my-gitlab"
@@ -12,10 +11,8 @@ in  Monocle.Config::{
             , provider =
                 Monocle.Provider.Gitlab
                   Monocle.Gitlab::{
-                  , gitlab_url = Some "https://gitlab.example.com"
-                  , gitlab_token = "gitlab-api-key"
-                  , gitlab_repositories = Some
-                    [ "my-org/project", "my-other-org/other-project" ]
+                  , gitlab_organization = "my-org"
+                  , gitlab_repositories = Some [ "project", "other/project" ]
                   }
             }
           , Monocle.Crawler::{

--- a/example/demo-node.dhall
+++ b/example/demo-node.dhall
@@ -50,17 +50,12 @@ let --| Create a github organization configuration
     mkGHRepo =
       \(info : { org : Text, repo : Text }) ->
         Monocle.Github::{
-        , github_token = env:SECRET as Text ? ""
         , github_organization = info.org
         , github_repositories = Some [ info.repo ]
         }
 
 let mkGHOrg =
-      \(github_organization : Text) ->
-        Monocle.Github::{
-        , github_token = env:SECRET as Text ? ""
-        , github_organization
-        }
+      \(github_organization : Text) -> Monocle.Github::{ github_organization }
 
 let mkGHCrawler =
       \(provider : Monocle.Github.Type) ->
@@ -82,7 +77,6 @@ let --| The ansible index configuration
 
       in  Monocle.Workspace::{
           , name = "ansible"
-          , crawlers_api_key = env:CRAWLER_SECRET as Text ? ""
           , crawlers =
                 Prelude.List.map
                   Monocle.Github.Type
@@ -106,11 +100,7 @@ let --| The ansible index configuration
 let --| Create a github crawler configuration for monocle
     mkSimpleGHIndex =
       \(name : Text) ->
-        Monocle.Workspace::{
-        , name
-        , crawlers_api_key = env:CRAWLER_SECRET as Text ? ""
-        , crawlers = [ mkGHCrawler (mkGHOrg name) ]
-        }
+        Monocle.Workspace::{ name, crawlers = [ mkGHCrawler (mkGHOrg name) ] }
 
 let createSimpleGHIndexes =
       Prelude.List.map Text Monocle.Workspace.Type mkSimpleGHIndex


### PR DESCRIPTION
This change simplifies configuration by using Optional value
for token and update since.

This change also change the gitlab provider to be similar to
github.

Fixes https://github.com/change-metrics/monocle/issues/525