### PR TITLE
Add the About Package

### DIFF
--- a/Monocle/About/Type.dhall
+++ b/Monocle/About/Type.dhall
@@ -1,0 +1,1 @@
+{ links : List ../Link/Type.dhall }

--- a/Monocle/About/Type.dhall
+++ b/Monocle/About/Type.dhall
@@ -1,1 +1,1 @@
-{ links : List { name : Text, url : Text } }
+{ links : List ../Link/Type.dhall }

--- a/Monocle/About/Type.dhall
+++ b/Monocle/About/Type.dhall
@@ -1,1 +1,1 @@
-{ links : List ../Link/Type.dhall }
+{ links : List { name : Text, url : Text } }

--- a/Monocle/About/default.dhall
+++ b/Monocle/About/default.dhall
@@ -1,0 +1,1 @@
+{ links = [] : List ../Link/Type.dhall }

--- a/Monocle/About/default.dhall
+++ b/Monocle/About/default.dhall
@@ -1,1 +1,1 @@
-{ links = [] : List { name : Text, url : Text } }
+{ links = [] : List ../Link/Type.dhall }

--- a/Monocle/About/default.dhall
+++ b/Monocle/About/default.dhall
@@ -1,1 +1,1 @@
-{ links = [] : List ../Link/Type.dhall }
+{ links = [] : List { name : Text, url : Text } }

--- a/Monocle/About/package.dhall
+++ b/Monocle/About/package.dhall
@@ -1,0 +1,1 @@
+{ Type = ./Type.dhall, default = ./default.dhall }

--- a/Monocle/Config.dhall
+++ b/Monocle/Config.dhall
@@ -1,1 +1,0 @@
-{ workspaces : List ./Workspace/Type.dhall }

--- a/Monocle/Config/Type.dhall
+++ b/Monocle/Config/Type.dhall
@@ -1,0 +1,3 @@
+{ about : Optional ../About/Type.dhall
+, workspaces : List ../Workspace/Type.dhall
+}

--- a/Monocle/Config/default.dhall
+++ b/Monocle/Config/default.dhall
@@ -1,0 +1,3 @@
+{ about = None ../About/Type.dhall
+, workspaces = [] : List ../Workspace/Type.dhall
+}

--- a/Monocle/Config/package.dhall
+++ b/Monocle/Config/package.dhall
@@ -1,0 +1,1 @@
+{ Type = ./Type.dhall, default = ./default.dhall }

--- a/Monocle/Link/Type.dhall
+++ b/Monocle/Link/Type.dhall
@@ -1,0 +1,1 @@
+{ display_text : Text, url : Text }

--- a/Monocle/Link/Type.dhall
+++ b/Monocle/Link/Type.dhall
@@ -1,1 +1,0 @@
-{ display_text : Text, url : Text }

--- a/Monocle/Link/Type.dhall
+++ b/Monocle/Link/Type.dhall
@@ -1,1 +1,1 @@
-{ display_text : Text, url : Text }
+{ name : Text, url : Text }

--- a/Monocle/Link/Type.dhall
+++ b/Monocle/Link/Type.dhall
@@ -1,1 +1,1 @@
-{ name : Text, url : Text }
+{ name : Text, url : Text, category : Optional Text }

--- a/Monocle/Link/default.dhall
+++ b/Monocle/Link/default.dhall
@@ -1,0 +1,1 @@
+{ category = None Text }

--- a/Monocle/Link/package.dhall
+++ b/Monocle/Link/package.dhall
@@ -1,0 +1,1 @@
+{ Type = ./Type.dhall, default = {=} }

--- a/Monocle/Link/package.dhall
+++ b/Monocle/Link/package.dhall
@@ -1,1 +1,1 @@
-{ Type = ./Type.dhall, default = {=} }
+{ Type = ./Type.dhall, default = ./default.dhall }

--- a/Monocle/Link/package.dhall
+++ b/Monocle/Link/package.dhall
@@ -1,1 +1,0 @@
-{ Type = ./Type.dhall, default = {=} }

--- a/Monocle/Utils.dhall
+++ b/Monocle/Utils.dhall
@@ -1,18 +1,20 @@
 let Prelude =
-      https://prelude.dhall-lang.org/v17.0.0/package.dhall sha256:10db3c919c25e9046833df897a8ffe2701dc390fa0893d958c3430524be5a43e
+      https://prelude.dhall-lang.org/v17.0.0/package.dhall
+        sha256:10db3c919c25e9046833df897a8ffe2701dc390fa0893d958c3430524be5a43e
 
-let Monocle = { Workspace.Type = ./Workspace/Type.dhall }
+let Config = ./Config/Type.dhall
+
+let Workspace = ./Workspace/Type.dhall
 
 let getIndexNames =
-      λ(config : { workspaces : List Monocle.Workspace.Type }) →
+      λ(config : Config) →
         Prelude.List.map
-          Monocle.Workspace.Type
+          Workspace
           Text
-          (λ(index : Monocle.Workspace.Type) → index.name)
+          (λ(index : Workspace) → index.name)
           config.workspaces
 
 let getIndexNamesList =
-      λ(config : { workspaces : List Monocle.Workspace.Type }) →
-        Prelude.Text.concatSep "\n" (getIndexNames config)
+      λ(config : Config) → Prelude.Text.concatSep "\n" (getIndexNames config)
 
 in  { getIndexNames, getIndexNamesList }

--- a/Monocle/package.dhall
+++ b/Monocle/package.dhall
@@ -9,6 +9,8 @@
 , SearchAlias = ./SearchAlias/package.dhall
 , Workspace = ./Workspace/package.dhall
 , Ident = ./Ident/package.dhall
-, Config = { Type = ./Config.dhall, default = {=} }
+, Config = ./Config/package.dhall
 , Utils = ./Utils.dhall
+, About = ./About/package.dhall
+, Link = ./Link/package.dhall
 }

--- a/Monocle/package.dhall
+++ b/Monocle/package.dhall
@@ -12,5 +12,4 @@
 , Config = ./Config/package.dhall
 , Utils = ./Utils.dhall
 , About = ./About/package.dhall
-, Link = ./Link/package.dhall
 }

--- a/Monocle/package.dhall
+++ b/Monocle/package.dhall
@@ -12,4 +12,5 @@
 , Config = ./Config/package.dhall
 , Utils = ./Utils.dhall
 , About = ./About/package.dhall
+, Link = ./Link/package.dhall
 }

--- a/example/config.dhall
+++ b/example/config.dhall
@@ -6,6 +6,7 @@ in  Monocle.Config::{
         [ Monocle.Link::{
           , name = "Link text"
           , url = "https://github.com/change-metrics/monocle"
+          , category = Some "Community"
           }
         ]
       }

--- a/example/config.dhall
+++ b/example/config.dhall
@@ -1,6 +1,14 @@
 let Monocle = ../package.dhall
 
 in  Monocle.Config::{
+    , about = Some Monocle.About::{
+      , links =
+        [ Monocle.Link::{
+          , display_text = "Link text"
+          , url = "https://github.com/change-metrics/monocle"
+          }
+        ]
+      }
     , workspaces =
       [ Monocle.Workspace::{
         , name = "demo-index"

--- a/example/config.dhall
+++ b/example/config.dhall
@@ -3,7 +3,8 @@ let Monocle = ../package.dhall
 in  Monocle.Config::{
     , about = Some Monocle.About::{
       , links =
-        [ { name = "Link text"
+        [ Monocle.Link::{
+          , display_text = "Link text"
           , url = "https://github.com/change-metrics/monocle"
           }
         ]

--- a/example/config.dhall
+++ b/example/config.dhall
@@ -4,7 +4,7 @@ in  Monocle.Config::{
     , about = Some Monocle.About::{
       , links =
         [ Monocle.Link::{
-          , display_text = "Link text"
+          , name = "Link text"
           , url = "https://github.com/change-metrics/monocle"
           }
         ]

--- a/example/config.dhall
+++ b/example/config.dhall
@@ -3,8 +3,7 @@ let Monocle = ../package.dhall
 in  Monocle.Config::{
     , about = Some Monocle.About::{
       , links =
-        [ Monocle.Link::{
-          , display_text = "Link text"
+        [ { name = "Link text"
           , url = "https://github.com/change-metrics/monocle"
           }
         ]


### PR DESCRIPTION
The About package allows to defined a list of Link. The primary
usage is to populate an AboutModal in the Monocle WEB app.